### PR TITLE
Add IP address and port validation (issue #8)

### DIFF
--- a/ha-chromium-kiosk-setup.sh
+++ b/ha-chromium-kiosk-setup.sh
@@ -267,21 +267,83 @@ check_remove_user() {
     fi
 }
 
+# Function to validate IP address format
+validate_ip() {
+    local ip=$1
+    local valid=1
+
+    # Check if the IP is in the correct format (IPv4)
+    if [[ $ip =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+        # Split the IP into octets
+        IFS='.' read -r -a octets <<< "$ip"
+
+        # Check if each octet is between 0 and 255
+        for octet in "${octets[@]}"; do
+            if [[ $octet -lt 0 || $octet -gt 255 ]]; then
+                valid=0
+                break
+            fi
+        done
+    else
+        valid=0
+    fi
+
+    # Also allow hostnames
+    if [[ $valid -eq 0 && $ip =~ ^[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?)*$ ]]; then
+        valid=1
+    fi
+
+    return $valid
+}
+
+# Function to validate port number
+validate_port() {
+    local port=$1
+
+    # Check if the port is a number and within the valid range (1-65535)
+    if [[ $port =~ ^[0-9]+$ && $port -ge 1 && $port -le 65535 ]]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
 # Prompt user function
 prompt_user() {
     local var_name=$1
     local prompt_message=$2
     local default_value=$3
 
-    read -p "$prompt_message [$default_value]: " value
-    value=${value:-$default_value}
+    while true; do
+        read -p "$prompt_message [$default_value]: " value
+        value=${value:-$default_value}
 
-    if [[ -z "$value" && -z "$default_value" ]]; then
-        echo "Error: $var_name is required. Please run the script again."
-        exit 1
-    fi
+        if [[ -z "$value" && -z "$default_value" ]]; then
+            echo "Error: $var_name is required. Please enter a value."
+            continue
+        fi
 
-    eval $var_name=\$value
+        # Validate IP address if the variable is HA_IP
+        if [[ "$var_name" == "HA_IP" ]]; then
+            if ! validate_ip "$value"; then
+                echo "Error: Invalid IP address or hostname format. Please enter a valid IPv4 address (e.g., 192.168.1.100) or hostname."
+                continue
+            fi
+        fi
+
+        # Validate port number if the variable is HA_PORT
+        if [[ "$var_name" == "HA_PORT" ]]; then
+            if ! validate_port "$value"; then
+                echo "Error: Invalid port number. Please enter a number between 1 and 65535."
+                continue
+            fi
+        fi
+
+        break
+    done
+
+    # Use declare instead of eval for secure variable assignment
+    declare -g "$var_name"="$value"
 }
 
 # Check and backup existing configuration files


### PR DESCRIPTION
This commit adds proper validation for IP addresses and port numbers:
- Added validate_ip function to check IPv4 addresses and hostnames
- Added validate_port function to check port numbers
- Updated prompt_user function to use these validation functions
- Added user-friendly error messages for invalid inputs
- Implemented a loop to keep prompting until valid input is provided
- Also fixed the security issue with eval by using declare instead